### PR TITLE
cloud-init 작동 가능하게 수정

### DIFF
--- a/shop2/cloud-init
+++ b/shop2/cloud-init
@@ -7,16 +7,18 @@ packages:
   - unixodbc-dev
   - build-essential
 runcmd:
+  - sudo su
   - curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
   - curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
   - apt update
   - ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools
+  - su - <vm_user>
   - python3 -m pip install flask sqlalchemy waitress pyodbc
   - cd /opt
   - git clone https://github.com/jaehwachung/cloud_computing.git
   - cd /opt/cloud_computing/shop2
-  - python3 manage.py db_info --host="<db_host>" --user="<db_user>" --password="<db_user_password>" --db="<db name>"
-  - python3 manage.py create_db
-  - python3 manage.py user_create
-  - python3 manage.py goods_insert
+  - python3 manage.py db-info --host='<db_host>' --user='<db_user>' --password='<db_user_password>' --db='<db_name>'
+  - python3 manage.py create-db
+  - python3 manage.py user-create
+  - python3 manage.py goods-insert
   - python3 shop_main.py


### PR DESCRIPTION
기존 cloud-init 이 작동하지 않아 수정해보았습니다.

- 앞부분은 루트 사용자로 수행하도록 했습니다.
  - 다른 부분은 `sudo` 만 붙여도 되지만, 두번째 커맨드는 루트 유저로만 수행가능하다고해서입니다.
- 함수의 `_` 을 `-` 로 변경하였습니다.
- DB 사용자 넣는 부분을 `"` 을 `'` 로 변경하였습니다.

다음과 같이 잘 작동하는 것을 확인하였습니다.

![image](https://user-images.githubusercontent.com/3617005/139520571-2217ca50-8232-4c51-b642-a9fe620a4f84.png)